### PR TITLE
Change to server/index.js not to need certificates if only using http

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Display all your connected webcams on a single webpage.
 Great for usability testing recordings and screencasts, stopwatch is included.
 
 ## Requirements
-- A connected webcam / videoinput (wow!)
+- A connected webcam / videoinput (wow!) and works with multiple cameras
 - A modern browser with [mediaDevices Web API](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices)
 
 ## Features
@@ -13,7 +13,7 @@ Great for usability testing recordings and screencasts, stopwatch is included.
 
 ## Capture
 - use any screensharing app like skype to broadcast 
-- Mac-users can use pre-installed quicktime to capture via "screencast" recording
+- Mac-users can use pre-installed quicktime to capture via "screencast" recording. Start Quicktime Player and choose `File/New Screen Recording`
 
 ## Tech
 - Based on the awesome [react-boilerplate](https://github.com/react-boilerplate/react-boilerplate)
@@ -24,8 +24,15 @@ See it working in action: [Click here](https://hamsterbacke23.github.io/webcamdi
 
 ## Local
 1) Clone it 
-2) run it
+2) If you are using an https server then you need to make sure that the SSL key
+and certificate are in /certificates/server.key and server.cert respectively.
+This directory is ignored and you should not check it in
+3) Then load the modules and start the server
+4) Note that for local browsers on MacOS High Sierra at least, Safari does not
+seem to work with http://localhost:3000 but this works fine with Google Chrome
 
-```yarn install```
-```npm start```
+```
+yarn install
+npm start
+```
 

--- a/app/containers/WebcamDisplay/index.js
+++ b/app/containers/WebcamDisplay/index.js
@@ -41,8 +41,8 @@ export class WebcamDisplay extends React.PureComponent { // eslint-disable-line 
     const constraints = {
       // originally 720p
       // video: { width: 1280, height: 720 },
-      video: { width: 1920, height: 1080 },
-      // video: { width: 3840,  height: 2160 },
+      // video: { width: 1920, height: 1080 },
+      video: { width: 3840, height: 2160 },
       deviceId: { exact: deviceId },
     };
 

--- a/app/containers/WebcamDisplay/index.js
+++ b/app/containers/WebcamDisplay/index.js
@@ -39,7 +39,10 @@ export class WebcamDisplay extends React.PureComponent { // eslint-disable-line 
 
   startVideo(deviceId) {
     const constraints = {
-      video: { width: 1280, height: 720 },
+      // originally 720p
+      // video: { width: 1280, height: 720 },
+      video: { width: 1920, height: 1080 },
+      // video: { width: 3840,  height: 2160 },
       deviceId: { exact: deviceId },
     };
 


### PR DESCRIPTION
OK this version has mainly fixed README to make it clearer that a certificates directory is required for https server. 

Also the default is now http rather than https. Also moved the code looking for certificates to a conditional so that you do not have to have dummy certificate/server.key and server.crt if you are just using it locally.

Finally added a little to the README.md to explain how to start Quicktime player and also noted that for localist, Safari does not work out of the box.

Thanks much for this, next step for me will be to add variable resolutions on the video inputs. Great work!